### PR TITLE
Dockerfile: redundancias e imports relativos.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,12 @@ FROM python:latest
 RUN mkdir /as
 WORKDIR /as
 
-ADD requirements.txt /as/requirements.txt
+COPY requirements.txt /as/requirements.txt
 
-RUN pip install --index-url=http://pypi.python.org/simple/ --trusted-host pypi.python.org -r requirements.txt
+RUN pip install -r requirements.txt
 
-ADD src /as/src
-ADD src /as/src/main
-ADD src /as/src/test
+COPY src /as/src
 
 EXPOSE 3000
 
-CMD [ "gunicorn", "src.app:app", "-b 0.0.0.0:3000" ]
+CMD [ "gunicorn", "--chdir", "src", "app:app", "-b 0.0.0.0:3000" ]

--- a/src/app.py
+++ b/src/app.py
@@ -1,10 +1,10 @@
 from flask import Flask
-from .main.user.user_controller import user_controller
-from .main.travels.travels_controller import travels_controller
-from .main.position.position_controller import position_controller
-from .main.drivers.drivers_controller import drivers_controller
-from .main.path.path_controller import path_controller
-from .main.login.login_controller import login_controller
+from main.user.user_controller import user_controller
+from main.travels.travels_controller import travels_controller
+from main.position.position_controller import position_controller
+from main.drivers.drivers_controller import drivers_controller
+from main.path.path_controller import path_controller
+from main.login.login_controller import login_controller
 
 app = Flask(__name__)
 

--- a/src/main/login/login_service.py
+++ b/src/main/login/login_service.py
@@ -1,4 +1,4 @@
-from ..main.firebase import firebase_service
+from ..firebase import firebase_service
 
 def login(request):
     id_token = request.form['Authorization']


### PR DESCRIPTION
Arreglos del Dockerfile:

-   Reemplazo `ADD` por `COPY` según sugerencia del linter para archivos locales.
-   Quito los `ADD` redundantes (`ADD src /as/src/main` y `ADD src /as/src/test`) que repetían todo `src` en otras direcciones.
-   Agrego argumento `chdir` a `gunicorn` que cambia de path a `src` antes de levantar la aplicación `app`.

Arreglos de path:

-   Quito la relatividad en `app.py`.
-   Quito el `main` de más de `login_service`. Antes funcionaba por la redundancia de archivos. Al quitar la redundancia explotaba.